### PR TITLE
[ADD]: loginRequest에 nickname 파라미터 추가

### DIFF
--- a/NOTI_Teacher/NOTI_Teacher/Global/Network/AuthAPI.swift
+++ b/NOTI_Teacher/NOTI_Teacher/Global/Network/AuthAPI.swift
@@ -23,19 +23,23 @@ extension AuthAPI {
     }
     
     /// [GET] 헤더에 kakaoAccessToken을 붙여 로그인을 요청하는 메서드
-    func loginRequest<T: Decodable>(with urlResource: URLResource<T>, token: String) -> Observable<Result<T, APIError>> {
+    func loginRequest<T: Decodable>(with urlResource: URLResource<T>, token: String, nickname: String? = nil) -> Observable<Result<T, APIError>> {
         Observable<Result<T, APIError>>.create { observer in
             let headers: HTTPHeaders = [
                 "Content-Type": "application/json",
                 "access-token": token
             ]
             
+            let param: Parameters? = nickname != nil ? ["nickname" : nickname!] : nil
+            
             let task = AF.request(urlResource.resultURL,
                                   method: .post,
+                                  parameters: param,
                                   encoding: JSONEncoding.default,
                                   headers: headers)
                 .validate(statusCode: 200...399)
                 .responseDecodable(of: T.self) { response in
+                    dump(response)
                     switch response.result {
                     case .success(let data):
                         guard let token = data as? TokensResponseModel else { return }

--- a/NOTI_Teacher/NOTI_Teacher/Screen/Login/ViewController/LoginVC.swift
+++ b/NOTI_Teacher/NOTI_Teacher/Screen/Login/ViewController/LoginVC.swift
@@ -180,8 +180,8 @@ extension LoginVC: ASAuthorizationControllerDelegate {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             guard let appleToken = String(data: appleIDCredential.identityToken!, encoding: .utf8) else { return }
             UserDefaults.standard.set(appleToken, forKey: UserDefaults.Keys.appleToken)
-            
-            viewModel.loginRequest(type: .apple)
+            viewModel.loginRequest(type: .apple,
+                                   nickname: appleIDCredential.fullName?.givenName)
             
         case let passwordCredential as ASPasswordCredential:
             // TODO: -

--- a/NOTI_Teacher/NOTI_Teacher/Screen/Login/ViewModel/LoginVM.swift
+++ b/NOTI_Teacher/NOTI_Teacher/Screen/Login/ViewModel/LoginVM.swift
@@ -84,11 +84,11 @@ extension LoginVM {
         }
     }
     
-    func loginRequest(type: LoginType) {
+    func loginRequest(type: LoginType, nickname: String? = nil) {
         let path = "api/teacher/login/\(type.rawValue)"
         let resource = URLResource<TokensResponseModel>(path: path)
         
-        AuthAPI.shared.loginRequest(with: resource, token: type.token)
+        AuthAPI.shared.loginRequest(with: resource, token: type.token, nickname: nickname)
             .withUnretained(self)
             .subscribe(onNext: { owner, result in
                 switch result {


### PR DESCRIPTION
## PR 요약
애플 신규 로그인(회원가입) 시, 닉네임을 전달하기 위해 loginRequest에서 nickname값을 파라미터로 전달하는 코드 추가
(* 가입 이력이 있거나 nil 값이 전달되는 경우 서버에서 자동으로 Noti를 닉네임으로 지정)

재 로그인 및 카카오 로그인의 경우 파라미터를 nil로 post 요청




